### PR TITLE
Update Dockerfile,Optimize user experience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     gradle -b cli.gradle assemble --info; \
     mv ./build/libs/*.jar ./build/libs/reader.jar
 
-FROM openjdk:8-jdk-alpine
+FROM amazoncorretto:8u332-alpine3.14-jre
 # Install base packages
 RUN \
     # apk update; \


### PR DESCRIPTION
更换镜像版本为aws打补丁后的openjdk镜像（更新时间为2个月前），降低镜像存储占用(127.63 MB→74.81 MB），降低内存占用（单人版约减少50m）