### PR TITLE
fix: 更新代理地址

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -310,7 +310,7 @@ curl -fsSL https://get.docker.com | bash -s docker #国外服务器
 curl -fsSL https://get.docker.com | bash -s docker --mirror Aliyun #国内服务器
 
 # 下载项目里的 docker-compose.yaml
-wget https://ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/docker-compose.yaml
+wget https://mirror.ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/docker-compose.yaml
 # 根据 docker-compose.yaml 里面的注释编辑所需配置
 vim docker-compose.yaml
 # 保存
@@ -337,10 +337,10 @@ docker-compose pull && docker-compose up -d
 ```shell
 # 此脚本对甲骨文非Ubuntu系统,CentOS9可能不兼容。建议网上手动搜索
 #curl
-bash <(curl -L -s https://ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/reader.sh)
+bash <(curl -L -s https://mirror.ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/reader.sh)
 
 #wget
-bash <(wget -qO- --no-check-certificate https://ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/reader.sh)
+bash <(wget -qO- --no-check-certificate https://mirror.ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/reader.sh)
 
 ```
 

--- a/reader.sh
+++ b/reader.sh
@@ -79,7 +79,7 @@ install_dockercompose() {
         systemctl restart docker
         systemctl enable docker
         echo -e "${green} 正在安装docker-compose ${plain}"
-        curl -L "https://ghproxy.com/https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
+        curl -L "https://mirror.ghproxy.com/https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
     else
         echo -e "${green} 正在安装docker-compose ${plain}"
         apt update && apt install wget curl docker-compose -y
@@ -90,7 +90,7 @@ install_reader() {
     mkdir -p ${orgin_file_dir}/storage/data/default
     cd ${orgin_file_dir}
     rm docker-compose*
-    wget https://ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/docker-compose.yml
+    wget https://mirror.ghproxy.com/https://raw.githubusercontent.com/hectorqin/reader/master/docker-compose.yml
     echo -e "${green} 正在配置默认书源 ${plain}"
     wget https://jihulab.com/aoaostar/legado/-/raw/release/cache/6c35d84798ddbf4aad3fe3f0fd6cec53dd788be8.json -O storage/data/default/bookSource.json
     # 判断是否合法json


### PR DESCRIPTION
由于ghproxy.com域名已喜提 GFW，将文档更新到官方提供的新地址上。