### PR TITLE
update archlinux install

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -13,6 +13,7 @@
   - [WebDAV同步配置](#webdav同步配置)
   - [客户端](#客户端)
     - [Windows / MacOS / Linux](#windows--macos--linux)
+    - [Arch Linux 安装](#Arch-Linux-安装)
       - [配置文件](#配置文件)
     - [手机端](#手机端)
     - [服务器版](#服务器版)
@@ -185,6 +186,35 @@ reader:
 从 [releases](https://github.com/hectorqin/reader/releases) 下载对应平台安装包安装即可，需要安装java8及以上环境
 
 MacOS 版 `storage` 默认是 `用户目录/.reader/storage`，其它版本 `storage` 默认是 `程序目录/storage`
+
+### Arch Linux 安装
+
+从 [AUR 仓库](https://aur.archlinux.org/packages/reader-pro-bin)安装或[自建软件源](https://github.com/taotieren/aur-repo)
+
+
+```bash
+yay -Syu reader-pro
+# 开启开机自启
+sudo systemctl enable reader-pro-single
+sudo systemctl enable reader-pro-multi
+# 运行
+sudo systemctl start reader-pro-single
+sudo systemctl start reader-pro-multi
+# 状态
+sudo systemctl status reader-pro-single
+sudo systemctl status reader-pro-multi
+# 停止
+sudo systemctl stop reader-pro-single
+sudo systemctl stop reader-pro-multi
+# 停止开机自启
+sudo systemctl disable reader-pro-single
+sudo systemctl disable reader-pro-multi
+```
+
+> Arch Linux 的存储目录是 `/var/lib/reader-pro/`
+
+> Arch Linux 的配置文件是 `/usr/share/java/reader-pro/conf/application.properties`
+
 
 #### 配置文件
 


### PR DESCRIPTION
- 新增 Arch Linux AUR 安装方式
- 使用 systemd 管理 reader-pro 服务

```bash
❯ yay -Ql reader-pro-bin
reader-pro-bin /usr/
reader-pro-bin /usr/bin/
reader-pro-bin /usr/bin/reader-pro
reader-pro-bin /usr/lib/
reader-pro-bin /usr/lib/systemd/
reader-pro-bin /usr/lib/systemd/system/
reader-pro-bin /usr/lib/systemd/system/reader-pro-multi.service
reader-pro-bin /usr/lib/systemd/system/reader-pro-single.service
reader-pro-bin /usr/lib/sysusers.d/
reader-pro-bin /usr/lib/sysusers.d/reader-pro.conf
reader-pro-bin /usr/lib/tmpfiles.d/
reader-pro-bin /usr/lib/tmpfiles.d/reader-pro.conf
reader-pro-bin /usr/share/
reader-pro-bin /usr/share/java/
reader-pro-bin /usr/share/java/reader-pro/
reader-pro-bin /usr/share/java/reader-pro/conf/
reader-pro-bin /usr/share/java/reader-pro/conf/application.properties
reader-pro-bin /usr/share/java/reader-pro/reader-pro.jar
reader-pro-bin /var/
reader-pro-bin /var/lib/
reader-pro-bin /var/lib/reader-pro/
reader-pro-bin /var/log/
reader-pro-bin /var/log/reader-pro/

❯ sudo systemctl status reader-pro-single.service
● reader-pro-single.service - Reader Pro Single User Mode
Loaded: loaded (/usr/lib/systemd/system/reader-pro-single.service; disabled; preset: disabled)
Active: active (running) since Thu 2024-11-14 23:09:05 CST; 7s ago
Invocation: 75535376140a46bfb05650beacae695d
Main PID: 1404539 (java)
Tasks: 42 (limit: 95896)
Memory: 319.8M (peak: 343.4M)
CPU: 8.746s
CGroup: /system.slice/reader-pro-single.service
└─1404539 /usr/lib/jvm/default/bin/java -Xms256m -Xmx256m -Xmn128m -Dreader.app.secure=false -Dreader.app.storagePath=/var/lib/reader-pro "-Xlog:gc*:file=/var/log/reader-pro/reader_gc.log:time,tags:filecount=10,fi>

11月 14 23:09:06 14s reader-pro[1404539]: 2024-11-14 23:09:06 [] [main] INFO  c.htmake.reader.ReaderApplicationKt - No active profile set, falling back to default profiles: default
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  com.htmake.reader.api.YueduApi - port: 8080
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  com.htmake.reader.api.YueduApi - serverPort: 8080
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  com.htmake.reader.utils.Ext - Using workdir: /var/lib/reader-pro
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  c.h.reader.verticle.RestVerticle - port: 8080
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [main] INFO  o.s.s.c.ThreadPoolTaskScheduler - Initializing ExecutorService 'taskScheduler'
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  c.h.reader.verticle.RestVerticle - Server running at: http://localhost:8080
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [vert.x-eventloop-thread-0] INFO  c.h.reader.verticle.RestVerticle - Web reader running at: http://localhost:8080
11月 14 23:09:07 14s reader-pro[1404539]: ReaderApplication Started
11月 14 23:09:07 14s reader-pro[1404539]: 2024-11-14 23:09:07 [] [main] INFO  c.htmake.reader.ReaderApplicationKt - Started ReaderApplicationKt in 1.45 seconds (JVM running for 1.798)
lines 1-21/21 (END)
❯ cat /var/log/reader-pro/start.out
启动命令：
/usr/lib/jvm/default/bin/java  -Xms256m -Xmx256m -Xmn128m -Dreader.app.secure=false -Dreader.app.storagePath=/var/lib/reader-pro -Xlog:gc*:file=/var/log/reader-pro/reader_gc.log:time,tags:filecount=10,filesize=100m -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dreader.app.workDir=/var/lib/reader-pro -Dspring.config.location=file:/usr/share/java/reader-pro/conf/application.properties -jar /usr/share/java/reader-pro/reader-pro.jar

Reader 正在启动中，你可以在 /var/log/reader-pro/start.out 查看日志
```

![图片](https://github.com/user-attachments/assets/b4403719-0b26-4849-9fd8-39a9ba7eac4b)
